### PR TITLE
Allow for Unrevealed Clues

### DIFF
--- a/jscrape/jscrape/category.py
+++ b/jscrape/jscrape/category.py
@@ -35,7 +35,8 @@ class Category:
 	
 	A Category consists of a name, possibly a note, and five clues ordered from lowest-valued (and easiest) to
 	highest-valued (and hardest). A Category can be played in either the Jeopardy! round or the Double Jeopardy! round,
-	and as such is not associated with any dollar amounts.
+	and as such is not associated with any dollar amounts. Clues are revealed to both the players and the audience
+	progressively; not all clues in a Category are guaranteed to be shown.
 	"""
 
 	def __init__(self, header: Element, q1: Element, q2: Element, q3: Element, q4: Element, q5: Element) -> None:
@@ -58,4 +59,4 @@ class Category:
 		header_rows: List[Element] = header.cssselect("tr")
 		self.name: str = header_rows[0].text_content()
 		self.note: Optional[str] = _get_category_note(header_rows[1].text_content())
-		self.clues: List[Clue] = [Clue(q1), Clue(q2), Clue(q3), Clue(q4), Clue(q5)]
+		self.clues: List[Optional[Clue]] = [Clue.create(q) for q in (q1, q2, q3, q4, q5)]

--- a/jscrape/jscrape/clue.py
+++ b/jscrape/jscrape/clue.py
@@ -1,4 +1,5 @@
 from lxml.html import HtmlElement as Element
+from typing import Optional
 
 
 class Clue:
@@ -13,9 +14,29 @@ class Clue:
 	def __init__(self, cell: Element) -> None:
 		"""
 		Initializes a Clue.
+
+		Note that this function should **not** be called directly. To create a new instance of the Clue class, use the
+		``Clue.create`` function, which is capable of handling Clues that were not actually revealed during the game.
 		
 		:param cell: The ``<td>`` element from the J!Archive HTML document in which the Clue is displayed.
 		"""
 		self.answer: str = cell.cssselect(".clue_text")[0].text_content()
 		self.question: str = cell.cssselect(".correct_response")[0].text_content()
 		self.is_daily_double: bool = bool(cell.cssselect(".clue_value_daily_double"))
+
+	@classmethod
+	def create(cls, cell: Element) -> Optional["Clue"]:
+		"""
+		Creates a Clue from a ``<td>`` element that may or may not contain an exposed Clue.
+
+		Clues are only exposed if one of the players selects the category/amount during gameplay. Depending on the speed
+		of the game, some Clues may stay unrevealed, in which case neither the players nor the audience get to see them.
+		Within J!Archive, such Clues are displayed as blank squares in the table grid.
+
+		:param cell: The ``<td>`` element from the J!Archive HTML document in which the Clue would be displayed if it
+		  was revealed.
+		"""
+		if not list(cell):
+			return None
+		else:
+			return cls(cell)

--- a/jscrape/jscrape/round.py
+++ b/jscrape/jscrape/round.py
@@ -11,7 +11,8 @@ class Round:
 	A Jeopardy! game is broken into three rounds: Jeopardy! (sometimes called "Single Jeopardy!"), Double Jeopardy! and
 	Final Jeopardy! The first two rounds each consist of 30 clues broken into six categories; clues are valued starting
 	at $200 for the Jeopardy! round and $400 for the Double Jeopardy! round, with each subsequent clue incrementing in
-	value by that same amount.
+	value by that same amount. Not all of the 30 clues in the round are guaranteed to be revealed over the course of the
+	game.
 	"""
 
 	def __init__(self, table: Element) -> None:


### PR DESCRIPTION
This commit adds logic to handle Clues that are not revealed during gameplay. The Category now has a collection of _optional_ Clues, with a factory creation method used to handle the possible absence. Clues are generally unrevealed if the players run out of time during the Round, and on J!Archive they are displayed as blank squares on the grid.